### PR TITLE
add query_pushes_by_specified_revision_range function

### DIFF
--- a/pylib/mozhginfo/mozhginfo/pushlog_client.py
+++ b/pylib/mozhginfo/mozhginfo/pushlog_client.py
@@ -92,6 +92,27 @@ def query_pushes_by_pushid_range(repo_url, start_id, end_id, version=2):
     return push_list
 
 
+def query_pushes_by_specified_revision_range(repo_url, revision, before, after):
+    """
+    Get the start and end revisions' pushlog based on the number of revisions before and after.
+    Raises PushlogError if pushlog data cannot be retrieved.
+    repo_url - represents the URL to clone a rep
+    revision - the revision been used to set the query range
+    before   - the number before the revision been given
+    after    - the number after the revision been given
+    """
+    try:
+        push = query_push_by_revision(repo_url, revision)
+        pushid = int(push.id)
+        start_id = pushid - before
+        end_id = pushid + after
+        push_list = query_pushes_by_pushid_range(repo_url, start_id, end_id)
+    except:
+        raise PushlogError('Unable to retrieve pushlog data. '
+                           'Please check repo_url and revision specified.')
+    return push_list
+
+
 def query_push_by_revision(repo_url, revision, full=False):
     """
     Return a dictionary with meta-data about a push including:

--- a/pylib/mozhginfo/tests/test_pushlog_client.py
+++ b/pylib/mozhginfo/tests/test_pushlog_client.py
@@ -5,6 +5,7 @@ from mock import patch, Mock
 from mozhginfo import pushlog_client
 from mozhginfo.push import Push
 from mozhginfo.pushlog_client import (
+    query_pushes_by_specified_revision_range,
     query_pushes_by_pushid_range,
     query_pushes_by_revision_range,
     query_push_by_revision,
@@ -111,6 +112,27 @@ class TestQueries(unittest.TestCase):
         for push in pushes:
             push_id_list.append(push.id)
             changeset_list.append(push.changesets[0].node)
+        assert push_id_list == ['53348', '53349', '53350']
+        assert changeset_list == ['eb15e3f893453d6a4472f8905271aba33f8b68d5',
+                                  '1c5b4332e2f1b73fe03977b69371e9a08503bff3',
+                                  '724f0a71d62171da1357e6c1f93453359e54206b']
+
+    @patch('requests.get', return_value=mock_response(LIST_REVISION, 200))
+    @patch('mozhginfo.pushlog_client.query_push_by_revision', return_value=push)
+    def test_query_pushes_by_specified_revision_range(self, get, query_push_by_revision):
+        pushes = query_pushes_by_specified_revision_range(repo_url=self.repo_url,
+                                                          revision=self.revision,
+                                                          before=1,
+                                                          after=1)
+        # This part is totally duplicate with the test_query_pushes_by_pushid_range,
+        # because we are calling query_pushes_by_pushid_range inside this function.
+        assert len(pushes) == 3
+        push_id_list = []
+        changeset_list = []
+        for push in pushes:
+            push_id_list.append(push.id)
+            changeset_list.append(push.changesets[0].node)
+
         assert push_id_list == ['53348', '53349', '53350']
         assert changeset_list == ['eb15e3f893453d6a4472f8905271aba33f8b68d5',
                                   '1c5b4332e2f1b73fe03977b69371e9a08503bff3',


### PR DESCRIPTION
We should add this function for mozci tool as replacement for query_revisions_range_from_revision_before_and_after in https://github.com/mozilla/mozilla_ci_tools/blob/master/mozci/sources/pushlog.py#L92