### PR TITLE
UnicodeDecodeError on some language systems when message is in unicode.

### DIFF
--- a/hgext/reviewboard/client.py
+++ b/hgext/reviewboard/client.py
@@ -262,13 +262,23 @@ def wrappedpush(orig, repo, remote, force=False, revs=None, newbranch=False,
 
     def filterwrite(messages):
         # Mercurial 3.5 sends the output as one string.
-        if messages[0].startswith('%sREVIEWBOARD' % _('remote: ')):
-            return True
+        tarMsg = '%sREVIEWBOARD' % _('remote: ')
+        try:
+            if messages[0].startswith(tarMsg):
+                return True
 
-        # Older versions have separate components.
-        if messages[0] == _('remote: ') and len(messages) >= 2 and \
-            messages[1].startswith('REVIEWBOARD: '):
-            return True
+            # Older versions have separate components.
+            if messages[0] == _('remote: ') and len(messages) >= 2 and \
+                messages[1].startswith('REVIEWBOARD: '):
+                return True
+        except UnicodeDecodeError:
+            if messages[0].startswith(tarMsg.decode('utf-8')):
+                return True
+
+            # Older versions have separate components.
+            if messages[0] == _('remote: ').decode('utf-8') and len(messages) >= 2 and \
+                messages[1].startswith(u'REVIEWBOARD: '):
+                return True
 
         return False
 


### PR DESCRIPTION
|'%sREVIEWBOARD' % _('remote: ')| is a byte str which may contains value over 127 if 'remote: ' is being translated to other language e.g. '遠端'  in chinese (which is '\xe9\x81\xa0\xe7\xab\xaf').
In some cases, I found the 'messages' passed in is in unicode str type, this caused an exception in |startswith()|.  So I'd like to provide a quick EAFP style fix.
