### PR TITLE
Permit backouts of NSS/NSPR

### DIFF
--- a/hghooks/mozhghooks/prevent_nspr_nss_changes.py
+++ b/hghooks/mozhghooks/prevent_nspr_nss_changes.py
@@ -23,6 +23,10 @@ def hook(ui, repo, node, source=None, **kwargs):
         if len(ctx.parents()) > 1:
             continue
 
+        # Permit backouts.
+        if "Backed out changeset" in ctx.description():
+            continue
+
         if any(f.startswith('nsprpub/') for f in ctx.files()):
             if 'UPGRADE_NSPR_RELEASE' not in ctx.description():
                 nspr_nodes.append(short(ctx.node()))


### PR DESCRIPTION
This makes it simpler for the `hg oops` command to operate on NSS/NSPR, without
having to edit the message to (arguably improperly) include the
`UPGRADE_..._RELEASE` flag. See
https://hg.mozilla.org/integration/autoland/rev/d82198f74526 for an example.