### PR TITLE
Spelling error fix

### DIFF
--- a/docs/devguide/contributing.rst
+++ b/docs/devguide/contributing.rst
@@ -19,7 +19,7 @@ Contacting Us
 =============
 
 The people that maintain the code in this repository lurk in the
-following Matric channels on ``chat.mozilla.org``:
+following Matrix channels on ``chat.mozilla.org``:
 
 #vcs
    Where everybody who maintains all the version control properties


### PR DESCRIPTION
Changed "Matric" to "Matrix". Spelling error has been uncaught since 2020.