### PR TITLE
s/.hg/requires/.hg/store/requires/

### DIFF
--- a/docs/hgmozilla/unifiedrepo.rst
+++ b/docs/hgmozilla/unifiedrepo.rst
@@ -160,7 +160,7 @@ repository operations.
 
 To check whether your existing Firefox clone is using generaldelta::
 
-   $ grep generaldelta .hg/requires
+   $ grep generaldelta .hg/store/requires
 
 If there is no ``generaldelta`` entry in that file, you will need to
 create a new repo that has generaldelta enabled. **Adding


### PR DESCRIPTION
hg moved most of the requirements to .hg/store/requires instead of .hg/requires.

E.g. see https://hg.mozilla.org/hgcustom/version-control-tools/rev/42f185d785a1418e8f328ba76474e3e31cb5e01c